### PR TITLE
Removing \strong because fontspec 2.6 already defines it

### DIFF
--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -186,7 +186,6 @@
 \newcommand{\acronym}[1]{\textsc{\fontspec[Numbers={OldStyle}]{Linux Libertine O}\MakeLowercase{#1}}}
 \newcommand{\uppersc}[1]{{\fontspec[Letters=UppercaseSmallCaps]{Linux Libertine O}#1}}
 \newcommand{\newterm}[1]{\index{#1}\emph{#1}}
-\newcommand{\strong}[1]{\textbf{#1}}
 \newcommand{\var}[1]{\textsl{#1}}
 \newcommand{\code}[1]{\texttt{#1}}
 \newcommand{\link}[1]{\hyperref[#1]{#1}}


### PR DESCRIPTION
This solves build issues with xelatex on new Tex Live (post 2012)