### PR TITLE
Update inkscape (1.4) CLI directives

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ exercises.tex figures.tex: ex-fig-ref.pl
 	./ex-fig-ref.pl -f > figures.tex
 
 %.pdf: %.svg
-	inkscape -f ${DIR}/$< -C -A ${DIR}/$@
+	inkscape --file=${DIR}/$< --export-area-drawing --batch-process --export-type=pdf --export-filename=${DIR}/$@
 
 clean:
 	latexmk -CA


### PR DESCRIPTION
Inkscape has undergone a considerable rewrite since last time this script was changed. As a result some options have either been removed or superseded by different CLI inputs.

Tested with InkScape 1.4 on Fedora 41.